### PR TITLE
Поправил Dockerfiles

### DIFF
--- a/Dockerfile.sse
+++ b/Dockerfile.sse
@@ -6,10 +6,11 @@ RUN apt-get update && apt-get install -y openjdk-17-jre
 RUN npm install -g supergateway
 
 WORKDIR /app
-COPY mcp-bsl-context.jar /app/mcp-bsl-context.jar
+ARG APP_VERSION=0.2.2
+COPY mcp-bsl-context-${APP_VERSION}.jar /app/mcp-bsl-context.jar
 
 # Expose the port for Streamable HTTP
 EXPOSE 8000
 
 # Run Supergateway with the MCP server JAR
-CMD ["npx", "-y", "supergateway", "--stdio", "java -jar /app/mcp-bsl-context.jar mcp-server --platform-path /app/1c-platform --verbose", "--port", "8000"]
+CMD ["npx", "-y", "supergateway", "--stdio", "java -jar /app/mcp-bsl-context.jar --platform-path /app/1c-platform --verbose", "--port", "8000"]

--- a/Dockerfile.stdio
+++ b/Dockerfile.stdio
@@ -1,13 +1,13 @@
 # Работает и на Intel, и на Apple Silicon
 FROM eclipse-temurin:17-jre-jammy
 
-ARG APP_VERSION=0.1.4
+ARG APP_VERSION=0.2.2
 
 WORKDIR /app
-COPY mcp-bsl-context.jar /app/mcp-bsl-context.jar
+COPY mcp-bsl-context-${APP_VERSION}.jar /app/mcp-bsl-context.jar
 
 # ENTRYPOINT чтобы STDIO сразу уходил наружу
-ENTRYPOINT ["java","-jar","/app/mcp-bsl-context.jar","mcp-server"]
+ENTRYPOINT ["java","-jar","/app/mcp-bsl-context.jar"]
 
 # Дополнительные аргументы (например --platform-path)
 # получим из docker run, поэтому CMD не задаём

--- a/documentation/MCP_SERVER_USAGE.md
+++ b/documentation/MCP_SERVER_USAGE.md
@@ -91,7 +91,7 @@ java -jar build/libs/mcp-bsl-context.jar \
 ```
 
 ### Запуск в Docker c STDIO
-- В папке с `Dockerfile'ом` рядом должен быть JAR-файл.
+- В папке с `Dockerfile'ом` рядом должен быть JAR-файл (например, `mcp-bsl-context-0.2.2.jar`).
 - Собираем docker image:
 ```bash
 docker build -t 1c-platform-mcp-server-stdio -f Dockerfile.stdio --build-arg APP_VERSION=х.х.х .
@@ -117,6 +117,26 @@ docker build -t 1c-platform-mcp-server-stdio -f Dockerfile.stdio --build-arg APP
     }
 }
 ```
+Если запуск будет в Windows, то путь к папке платформы должен быть без пробелов (и с экранированием слешей, если речь о конфигурации в JSON):
+```json
+{
+    "mcpServers": {
+        "1c-platform-stdio": {
+            "command": "docker",
+            "args": [
+                "run",
+                "--rm",
+                "-i",
+                "-v",
+                "C:\\ваша_папка_без_пробелов\\bin:/app/1c-platform:ro",
+                "1c-platform-mcp-server-stdio",
+                "--platform-path",
+                "/app/1c-platform"
+            ]
+        }
+    }
+}
+```
 
 ### Запуск в Docker c проксированием в SSE
 Это вариант, если хотите запускать MCP на удаленном хосте с доступом по сети.
@@ -124,7 +144,7 @@ docker build -t 1c-platform-mcp-server-stdio -f Dockerfile.stdio --build-arg APP
 - В папке с `Dockerfile'ом` рядом должен быть JAR-файл.
 - Собираем и запускаем docker:
 ```bash
-docker build -t 1c-platform-mcp-server-sse -f Dockerfile.sse --build-arg APP_VERSION=0.1.4 .
+docker build -t 1c-platform-mcp-server-sse -f Dockerfile.sse --build-arg APP_VERSION=0.2.2 .
 
 docker run -d \
   -v ./platform:/app/1c-platform:ro \
@@ -150,9 +170,9 @@ docker run -d \
 #### Получение образа
 
 ```bash
-docker pull ghcr.io/alkoleft/mcp-bsl-context:v0.2.1-sse
+docker pull ghcr.io/alkoleft/mcp-bsl-context:v0.2.2-sse
 # или для stdio:
-docker pull ghcr.io/alkoleft/mcp-bsl-context:v0.2.1-stdio
+docker pull ghcr.io/alkoleft/mcp-bsl-context:v0.2.2-stdio
 ```
 
 #### Запуск STDIO-версии
@@ -160,7 +180,7 @@ docker pull ghcr.io/alkoleft/mcp-bsl-context:v0.2.1-stdio
 ```bash
 docker run --rm -i \
   -v /path/to/1c/platform:/app/1c-platform:ro \
-  ghcr.io/alkoleft/mcp-bsl-context:v0.2.1-stdio \
+  ghcr.io/alkoleft/mcp-bsl-context:v0.2.2-stdio \
   --platform-path /app/1c-platform
 ```
 
@@ -170,7 +190,7 @@ docker run --rm -i \
 docker run -d \
   -v /path/to/1c/platform:/app/1c-platform:ro \
   -p 8001:8000 \
-  ghcr.io/alkoleft/mcp-bsl-context:v0.2.1-sse \
+  ghcr.io/alkoleft/mcp-bsl-context:v0.2.2-sse \
   --platform-path /app/1c-platform
 ```
 


### PR DESCRIPTION
Теперь не нужен параметр запуска "mcp-server".
Поэтому убрал его в докер файлах, иначе контейнер не стартовал с ошибкой разбора параметров.