### PR TITLE
Поддержка Streamable HTTP

### DIFF
--- a/Dockerfile.streamable
+++ b/Dockerfile.streamable
@@ -1,7 +1,7 @@
 # Работает и на Intel, и на Apple Silicon
 FROM eclipse-temurin:17-jre-jammy
 
-ARG APP_VERSION=0.2.2
+ARG APP_VERSION=0.3.2-SNAPSHOT
 
 WORKDIR /app
 COPY mcp-bsl-context-${APP_VERSION}.jar /app/mcp-bsl-context.jar

--- a/Dockerfile.streamable
+++ b/Dockerfile.streamable
@@ -7,10 +7,13 @@ WORKDIR /app
 COPY mcp-bsl-context-${APP_VERSION}.jar /app/mcp-bsl-context.jar
 
 # Create directory for 1C platform files
-RUN mkdir -p /app/1c-platform
+RUN addgroup --system app && adduser --system --ingroup app app \
+    && mkdir -p /app/1c-platform \
+    && chown -R app:app /app
 
 # Expose the port for Streamable HTTP
 EXPOSE 8080
 
 # Run the application in Streamable HTTP mode
+USER app
 CMD ["java", "-jar", "/app/mcp-bsl-context.jar", "--mode", "streamable", "--platform-path", "/app/1c-platform", "--port", "8080"]

--- a/Dockerfile.streamable
+++ b/Dockerfile.streamable
@@ -1,0 +1,16 @@
+# Работает и на Intel, и на Apple Silicon
+FROM eclipse-temurin:17-jre-jammy
+
+ARG APP_VERSION=0.2.2
+
+WORKDIR /app
+COPY mcp-bsl-context-${APP_VERSION}.jar /app/mcp-bsl-context.jar
+
+# Create directory for 1C platform files
+RUN mkdir -p /app/1c-platform
+
+# Expose the port for Streamable HTTP
+EXPOSE 8080
+
+# Run the application in Streamable HTTP mode
+CMD ["java", "-jar", "/app/mcp-bsl-context.jar", "--mode", "streamable", "--platform-path", "/app/1c-platform", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ java -Dfile.encoding=UTF-8 -jar mcp-bsl-context-<версия>.jar [опции]
 - `--platform-path`, `-p` - путь к каталогу установки 1С Предприятия
 - `--help`, `-h` - показать справку по использованию
 - `--verbose` - включить отладочное логирование
-- `--mode`, `-m` - режим работы: sse (HTTP Server-Sent Events) или stdio (стандартный ввод/вывод) (по умолчанию stdio)
-- `--port` - порт для SSE сервера (по умолчанию 8080)
+- `--mode`, `-m` - режим работы: `stdio` (стандартный ввод/вывод), `sse` (legacy HTTP Server-Sent Events) или `streamable` (MCP Streamable HTTP) (по умолчанию stdio)
+- `--port` - порт HTTP сервера для режимов `sse` и `streamable` (по умолчанию 8080)
 
 **Примеры:**
 
@@ -93,6 +93,9 @@ java -jar mcp-bsl-context-0.3.0.jar --mode sse --platform-path "/opt/1cv8/x86_64
 
 # SSE режим с кастомным портом
 java -jar mcp-bsl-context-0.3.0.jar --mode sse --port 9000 --platform-path "/opt/1cv8/x86_64/8.3.25.1257"
+
+# Streamable HTTP режим (рекомендуется для Codex)
+java -jar mcp-bsl-context-0.3.0.jar --mode streamable --platform-path "/opt/1cv8/x86_64/8.3.25.1257"
 
 # Сокращенная форма
 java -jar mcp-bsl-context-0.3.0.jar -m stdio -p "/opt/1cv8/x86_64/8.3.25.1257"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,9 +64,6 @@ dependencies {
     // JSON/XML with Kotlin support
     implementation(libs.bundles.jackson)
 
-    // Logging
-    implementation(libs.bundles.logging)
-
     // Reactor Core для Spring AI MCP
     implementation(libs.reactor.core)
 

--- a/documentation/02_SETUP.md
+++ b/documentation/02_SETUP.md
@@ -63,7 +63,7 @@ java -jar build/libs/mcp-bsl-context.jar --mode sse
 
 - `--platform-path` - путь к каталогу установки 1С Предприятия
 - `--mode` - режим работы (`stdio`, `sse` или `streamable`, по умолчанию `stdio`)
-- `--port` - порт для SSE режима (по умолчанию 8080)
+- `--port` - порт для HTTP режимов `sse` и `streamable` (по умолчанию 8080)
 - `--verbose` - включить отладочное логирование
 - `--help` - показать справку
 
@@ -127,5 +127,4 @@ java -jar build/libs/mcp-bsl-context.jar \
 - [Релизы](https://github.com/alkoleft/mcp-bsl-context/releases)
 - [SSE документация](SSE_USAGE.md)
 
-Для сообщения об ошибках создайте issue в репозитории проекта.
 Для сообщения об ошибках создайте issue в репозитории проекта.

--- a/documentation/02_SETUP.md
+++ b/documentation/02_SETUP.md
@@ -62,7 +62,7 @@ java -jar build/libs/mcp-bsl-context.jar --mode sse
 ### Параметры запуска
 
 - `--platform-path` - путь к каталогу установки 1С Предприятия
-- `--mode` - режим работы (`stdio` или `sse`, по умолчанию `stdio`)
+- `--mode` - режим работы (`stdio`, `sse` или `streamable`, по умолчанию `stdio`)
 - `--port` - порт для SSE режима (по умолчанию 8080)
 - `--verbose` - включить отладочное логирование
 - `--help` - показать справку

--- a/documentation/03_DOCKER.md
+++ b/documentation/03_DOCKER.md
@@ -80,6 +80,30 @@ docker run -d \
 }
 ```
 
+## Запуск в Docker c Streamable HTTP
+
+Вариант для HTTP-транспорта MCP в режиме `streamable` (рекомендуется для новых клиентов, включая Codex).
+
+```bash
+docker build -t 1c-platform-mcp-server-streamable -f Dockerfile.streamable --build-arg APP_VERSION=0.2.2 .
+
+docker run -d \
+  -v ./platform:/app/1c-platform:ro \
+  -p 8080:8080 \
+  1c-platform-mcp-server-streamable
+```
+
+### Пример настройки IDE/клиента при запуске в Docker с Streamable HTTP
+
+```json
+{
+    "mcpServers": {
+        "1c-platform-streamable": {
+            "url": "http://10.0.0.x:8080/mcp"
+        }
+}
+```
+
 Актуальную версию (APP_VERSION) смотрите в [релизах](https://github.com/alkoleft/mcp-bsl-context/releases)
 
 ## Быстрый старт с опубликованными Docker-образами

--- a/documentation/03_DOCKER.md
+++ b/documentation/03_DOCKER.md
@@ -77,6 +77,7 @@ docker run -d \
         "1c-platform-sse": {
             "url": "http://10.0.0.x:8001/sse"
         }
+    }
 }
 ```
 
@@ -101,6 +102,7 @@ docker run -d \
         "1c-platform-streamable": {
             "url": "http://10.0.0.x:8080/mcp"
         }
+    }
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.1.20"
 kotlin-logging = "7.0.3"
-springBoot = "3.5.3"
+springBoot = "3.5.11"
 springDependencyManagement = "1.1.7"
 gitVersioning = "6.4.4"
 gradleGitProperties = "2.4.2"
@@ -15,7 +15,7 @@ assertj = "3.8.0"
 slf4j-log4j12 = "1.7.30"
 kotlinx-cli = "0.3.6"
 
-springAi = "1.0.0"
+springAi = "1.1.4"
 ktlint = "1.4.1"
 jacoco = "0.8.11"
 
@@ -107,4 +107,4 @@ git-versioning = { id = "me.qoomon.git-versioning", version.ref = "gitVersioning
 gradle-git-properties = { id = "com.gorylenko.gradle-git-properties", version.ref = "gradleGitProperties" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
 spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }
-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" } 
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }

--- a/src/main/kotlin/ru/alkoleft/context/McpServerApplication.kt
+++ b/src/main/kotlin/ru/alkoleft/context/McpServerApplication.kt
@@ -33,15 +33,19 @@ fun main(args: Array<String>) {
     )
     val mode by parser
         .option(
-            ArgType.Choice(listOf("sse", "stdio"), { it }),
+            ArgType.Choice(listOf("sse", "stdio", "streamable"), { it }),
             shortName = "m",
             fullName = "mode",
-            description = "Режим работы: sse (HTTP Server-Sent Events) или stdio (стандартный ввод/вывод)",
+            description =
+                "Режим работы: " +
+                    "stdio (стандартный ввод/вывод), " +
+                    "sse (legacy HTTP Server-Sent Events), " +
+                    "streamable (MCP Streamable HTTP)",
         ).default("stdio")
     val ssePort by parser.option(
         ArgType.Int,
         fullName = "port",
-        description = "Порт для SSE сервера (по умолчанию 8080)",
+        description = "Порт HTTP сервера для режимов sse/streamable (по умолчанию 8080)",
     )
 
     parser.parse(args)
@@ -62,6 +66,13 @@ fun main(args: Array<String>) {
     when (mode) {
         "sse" -> {
             activeProfiles.add("sse")
+            if (ssePort != null) {
+                System.setProperty("server.port", ssePort.toString())
+            }
+        }
+
+        "streamable" -> {
+            activeProfiles.add("streamable")
             if (ssePort != null) {
                 System.setProperty("server.port", ssePort.toString())
             }

--- a/src/main/kotlin/ru/alkoleft/context/McpServerApplication.kt
+++ b/src/main/kotlin/ru/alkoleft/context/McpServerApplication.kt
@@ -23,13 +23,13 @@ fun main(args: Array<String>) {
         ArgType.String,
         shortName = "p",
         fullName = "platform-path",
-        description = "Путь к каталогу платформы 1С",
+        description = "Path to the 1C platform directory",
     )
     val verbose by parser.option(
         ArgType.Boolean,
         shortName = "v",
         fullName = "verbose",
-        description = "Включить отладочное логирование",
+        description = "Enable debug logging",
     )
     val mode by parser
         .option(
@@ -37,15 +37,15 @@ fun main(args: Array<String>) {
             shortName = "m",
             fullName = "mode",
             description =
-                "Режим работы: " +
-                    "stdio (стандартный ввод/вывод), " +
+                "Operating modes: " +
+                    "stdio (standard input/output), " +
                     "sse (legacy HTTP Server-Sent Events), " +
                     "streamable (MCP Streamable HTTP)",
         ).default("stdio")
-    val ssePort by parser.option(
+    val httpPort by parser.option(
         ArgType.Int,
         fullName = "port",
-        description = "Порт HTTP сервера для режимов sse/streamable (по умолчанию 8080)",
+        description = "HTTP server port for sse/streamable modes (default: 8080)",
     )
 
     parser.parse(args)
@@ -66,15 +66,15 @@ fun main(args: Array<String>) {
     when (mode) {
         "sse" -> {
             activeProfiles.add("sse")
-            if (ssePort != null) {
-                System.setProperty("server.port", ssePort.toString())
+            if (httpPort != null) {
+                System.setProperty("server.port", httpPort.toString())
             }
         }
 
         "streamable" -> {
             activeProfiles.add("streamable")
-            if (ssePort != null) {
-                System.setProperty("server.port", ssePort.toString())
+            if (httpPort != null) {
+                System.setProperty("server.port", httpPort.toString())
             }
         }
 

--- a/src/main/resources/application-sse.yml
+++ b/src/main/resources/application-sse.yml
@@ -4,5 +4,6 @@ spring:
     mcp:
       server:
         stdio: false
+        protocol: SSE
 server:
   port: ${SSE_PORT:8080}

--- a/src/main/resources/application-streamable.yml
+++ b/src/main/resources/application-streamable.yml
@@ -1,0 +1,9 @@
+# Профиль для Streamable HTTP режима
+spring:
+  ai:
+    mcp:
+      server:
+        stdio: false
+        protocol: STREAMABLE
+server:
+  port: ${MCP_HTTP_PORT:${SSE_PORT:8080}}

--- a/src/main/resources/application-streamable.yml
+++ b/src/main/resources/application-streamable.yml
@@ -5,5 +5,7 @@ spring:
       server:
         stdio: false
         protocol: STREAMABLE
+        streamable-http:
+          mcp-endpoint: /mcp
 server:
   port: ${MCP_HTTP_PORT:${SSE_PORT:8080}}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,15 +15,12 @@ spring:
 
         # Возможности сервера
         capabilities:
-          tools:
-            # Поддержка инструментов
-            enabled: true
-          resources:
-            # Поддержка ресурсов (отключено для простоты)
-            enabled: false
-          prompts:
-            # Поддержка промптов (отключено для простоты)
-            enabled: false
+          # Поддержка инструментов
+          tool: true
+          # Поддержка ресурсов (отключено для простоты)
+          resource: false
+          # Поддержка промптов (отключено для простоты)
+          prompt: false
   # Отключаем баннер Spring Boot для чистого STDIO вывода
   main:
     banner-mode: off


### PR DESCRIPTION
Closes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Добавлена поддержка режима Streamable HTTP для MCP сервера — доступно через CLI: --mode streamable (HTTP-порт по умолчанию 8080, опция --platform-path для пути платформы).
* **Documentation**
  * Обновлены руководства и примеры: описаны режимы stdio/sse/streamable, уточнено поведение опции --port для HTTP‑режимов и добавлены примеры запуска и контейнерного запуска.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->