### PR TITLE
issue-13: добавлена нормализация путей файлов для windows

### DIFF
--- a/src/main/kotlin/ru/alkoleft/context/infrastructure/hbk/toc/TocParser.kt
+++ b/src/main/kotlin/ru/alkoleft/context/infrastructure/hbk/toc/TocParser.kt
@@ -110,6 +110,8 @@ internal class TocParser {
         val number2 = parseNumber(iterator, "PropertiesContainer: ожидался number2")
         val nameContainer = parseNameContainer(iterator)
         val htmlPath = parseString(iterator, "PropertiesContainer: ожидался htmlPath")
+            .replace("\\", "/")
+            .replace("//", "/")
         expectToken(iterator, "}", "PropertiesContainer: ожидался '}' в конце")
         logger.debug { "    [PropertiesContainer] number1=$number1, number2=$number2, htmlPath=$htmlPath" }
         return PropertiesContainer(number1, number2, nameContainer, htmlPath)


### PR DESCRIPTION
Closes https://github.com/alkoleft/mcp-bsl-platform-context/issues/13

Для исправления ошибки "Не удалось инициализировать поисковые индексы" добавлена нормализация путей файлов для дистрибутива 1с платформы для windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок
* Улучшена нормализация путей при анализе конфигурации для повышения совместимости с различными форматами путей файлов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->